### PR TITLE
fixes #8 make lint failure exit with 0

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "start-prod": "NODE_ENV=production node dist/server/",
     "build": "./scripts/build.sh",
     "watch-client": "node webpack/webpack-dev-server.js",
-    "lint": "eslint -c .eslintrc.js '**/*.js'",
+    "lint": "eslint -c .eslintrc.js '**/*.js'; exit 0",
     "test": "npm run test:run && npm run lint",
     "test:run": "BABEL_DISABLE_CACHE=1 NODE_ENV=TEST nyc --require babel-core/register mocha --compilers js:babel-register --recursive",
     "test:watch": "npm run test:run -- --watch",


### PR DESCRIPTION
Preventing npm from capturing the error and throwing ELIFECYCLE error.

Could also do this for test:run, but that might mask other actual NPM errors, so I'll look into that separately.