### PR TITLE
use cheap-module-eval-source-map for faster rebuild speed in dev

### DIFF
--- a/webpack/dev-config.js
+++ b/webpack/dev-config.js
@@ -33,7 +33,7 @@ module.exports = {
   module: {
     loaders: require('./loaders-config.js')
   },
-  devtool: 'source-map',
+  devtool: '#cheap-module-eval-source-map',
   postcss: function () {
     return [ vars({ variables: () => sharedVars }), autoprefixer ];
   }


### PR DESCRIPTION
Didn't see a difference from source-maps when an error was thrown, and this is reportedly faster.