### PR TITLE
Simple thank you message after successful API response, mocked API

### DIFF
--- a/server/handlers/api.js
+++ b/server/handlers/api.js
@@ -6,18 +6,36 @@ const UBUNTU_SCA_URL = conf.get('UBUNTU_SCA_URL');
 export const customers = (req, res) => {
   const auth = req.session.authorization;
 
-  const options = {
-    uri: `${UBUNTU_SCA_URL}/purchases/v1/customers`,
-    headers: {
-      authorization: auth
-    },
-    json: true,
-    body: {
-      stripe_token: req.body.stripe_token
-    }
-  };
+  // FIXME:
+  // send real requests when we don't need mocked ones anymore
+  // const options = {
+  //   uri: `${UBUNTU_SCA_URL}/purchases/v1/customers`,
+  //   headers: {
+  //     authorization: auth
+  //   },
+  //   json: true,
+  //   body: {
+  //     stripe_token: req.body.stripe_token
+  //   }
+  // };
 
-  request.post(options).pipe(res);
+  // request.post(options).pipe(res);
+
+  // FIXME:
+  // sending mocked responses until
+  if (auth) {
+    res.status(200).json({
+      'accepted_tos_date': '2016-09-13T11:27:31+00:00',
+      'latest_tos_date': '2016-09-09T12:00:00+00:00',
+      'latest_tos_accepted': true,
+      'has_payment_method': true
+    });
+  } else {
+    res.status(401).json({
+      'code': 'auth-required',
+      'message': 'Authentication required.'
+    });
+  }
 };
 
 export const orders = (req, res) => {

--- a/src/actions/customer.js
+++ b/src/actions/customer.js
@@ -60,7 +60,7 @@ export function postStripeToken(token) {
     })
       .then(checkStatus)
       .then(response => response.json())
-      .then(json => dispatch(sendStripeTokenSuccess(json.tos_accepted)))
+      .then(json => dispatch(sendStripeTokenSuccess(json.latest_tos_accepted)))
       .catch(errors => dispatch(sendStripeTokenFailure(errors)));
   };
 }

--- a/src/components/customer-success/customer-success.css
+++ b/src/components/customer-success/customer-success.css
@@ -1,0 +1,9 @@
+.customerSuccess {
+  padding: 2em;
+  background: #FFF;
+}
+
+.code {
+  font-family: monospace;
+  background: $light-grey;
+}

--- a/src/components/customer-success/index.js
+++ b/src/components/customer-success/index.js
@@ -1,0 +1,32 @@
+import React, { PropTypes } from 'react';
+import { connect } from 'react-redux';
+
+import styles from './customer-success.css';
+
+export function CustomerSuccess(props) {
+  if (!props.customer.tosAccepted) {
+    return null;
+  }
+
+  return (
+    <div className={ styles.customerSuccess }>
+      <h3>Thank you</h3>
+      <p>Your payment details were successfully saved. Proceed with your purchases in command line using <code className={ styles.code }>snap buy</code> command.</p>
+    </div>
+  );
+
+}
+
+CustomerSuccess.propTypes = {
+  customer: PropTypes.shape({
+    isFetching: PropTypes.bool,
+    tosAccepted: PropTypes.bool
+  }),
+  dispatch: PropTypes.func.isRequired
+};
+
+function mapStateToProps(state) {
+  return { customer: state.customer };
+}
+
+export default connect(mapStateToProps)(CustomerSuccess);

--- a/src/containers/add-card.js
+++ b/src/containers/add-card.js
@@ -2,6 +2,8 @@ import React, { PropTypes, Component } from 'react';
 import { connect } from 'react-redux';
 
 import { postStripeToken } from '../actions/customer';
+
+import CustomerSuccess from '../components/customer-success';
 import PaymentDetails from '../components/payment-details';
 import PaymentsForm from '../components/payments-form';
 
@@ -19,6 +21,7 @@ export class AddCard extends Component {
       <div className={ styles.container }>
         <PaymentsForm />
         <PaymentDetails />
+        <CustomerSuccess />
         <button onClick={ boundClick }>Test Send Stripe Token</button>
       </div>
     );

--- a/test/routes/t_api.js
+++ b/test/routes/t_api.js
@@ -43,18 +43,20 @@ describe('purchases api', () => {
       'stripe_token': 'foo'
     };
 
+    // FIXME: responses are currently mocked in API
     // mock the request to SCA
-    const sca = nock(conf.get('UBUNTU_SCA_URL'))
-      .matchHeader('authorization', authorization)
-      .post('/purchases/v1/customers', body)
-      .reply(200);
+    // const sca = nock(conf.get('UBUNTU_SCA_URL'))
+    //   .matchHeader('authorization', authorization)
+    //   .post('/purchases/v1/customers', body)
+    //   .reply(200);
 
     // send the request via our handler
     testagent
       .post('/api/purchases/customers')
       .send(body)
       .expect(200, () => {
-        sca.done();
+        // FIXME: responses are currently mocked in API
+        // sca.done();
         done();
       });
   });

--- a/test/unit/actions/t_customer.js
+++ b/test/unit/actions/t_customer.js
@@ -79,7 +79,7 @@ describe('async actions', () => {
     const tosAccepted = '2016-09-12T10:16:20.779Z';
 
     scope.post('/api/purchases/customers')
-      .reply(200, { tos_accepted: tosAccepted });
+      .reply(200, { latest_tos_accepted: tosAccepted });
 
     const expectedActions = [
       { type: ActionTypes.SEND_STRIPE_TOKEN, token },


### PR DESCRIPTION
Simple success message that we can show up after successful response.
I guess we will need to confirm final copy text for that.

Also mocked Pay API for now, so we can test successful responses not relying on SCA for now.

<img width="941" alt="screen shot 2016-09-23 at 15 20 07" src="https://cloud.githubusercontent.com/assets/83575/18787294/8e4f0228-81a2-11e6-92d8-49ab9023c55d.png">
