### PR TITLE
Correctly passing errors in tests

### DIFF
--- a/test/routes/t_api.js
+++ b/test/routes/t_api.js
@@ -62,10 +62,10 @@ describe('purchases api', () => {
       testagent
       .post('/api/purchases/customers')
       .send(body)
-      .expect(200, () => {
+      .expect(200, (err) => {
         // FIXME: responses are currently mocked in API
         // sca.done();
-        done();
+        done(err);
       });
     });
 
@@ -85,9 +85,9 @@ describe('purchases api', () => {
       testagent
       .post('/api/purchases/orders')
       .send(body)
-      .expect(200, () => {
+      .expect(200, (err) => {
         sca.done();
-        done();
+        done(err);
       });
     });
   });


### PR DESCRIPTION
Correctly passing errors to `done` callback.
Without it tests will never fail as errors will be ignored.