### PR TITLE
Allow log path, host and port to be configured from nconf

### DIFF
--- a/server/configure.js
+++ b/server/configure.js
@@ -3,13 +3,18 @@ const development = require('../settings/development');
 const staging = require('../settings/staging');
 const production = require('../settings/production');
 
-nconf.env('__');
-nconf.env([
-  'UNIVERSAL:APP_URL', // env variable UNIVERSAL__APP_URL
-  'SESSION_SECRET',
-  'SESSION_MEMCACHED_HOST',
-  'SESSION_MEMCACHED_SECRET'
-]);
+nconf.env({
+  separator: '__',
+  whitelist: [
+    'SESSION_SECRET',
+    'SESSION_MEMCACHED_HOST',
+    'SESSION_MEMCACHED_SECRET',
+    'UNIVERSAL__MU_URL', // UNIVERSAL:MU_URL
+    'SERVER__HOST', // SERVER:HOST
+    'SERVER__PORT', // SERVER:PORT
+    'SERVER__LOGS_PATH' // SERVER:LOGS_PATH
+  ]
+});
 
 if (process.env.NODE_ENV === 'production') {
   if (process.env.DEPLOY_ENV === 'production') {

--- a/server/server.js
+++ b/server/server.js
@@ -17,8 +17,9 @@ import Html from '../src/helpers/html';
 import configureStore from '../src/store/configureStore';
 import sessionConfig from './helpers/session';
 
+const logsPath = conf.get('SERVER:LOGS_PATH') || path.join(__dirname, '../logs/');
 const accessLogStream = fs.createWriteStream(
-  path.join(__dirname, '../logs/', 'access.log'),
+  path.join(logsPath, 'access.log'),
   { flags: 'a' }
 );
 
@@ -92,7 +93,9 @@ function serve(webpackIsomorphicTools) {
   });
 
   const appUrl = url.parse(conf.get('UNIVERSAL:MU_URL'));
-  const server = app.listen(appUrl.port, appUrl.hostname, () => {
+  const appHost = conf.get('SERVER:HOST') || appUrl.hostname;
+  const appPort = conf.get('SERVER:PORT') || appUrl.port;
+  const server = app.listen(appPort, appHost, () => {
     const host = server.address().address;
     const port = server.address().port;
 

--- a/settings/production.js
+++ b/settings/production.js
@@ -4,6 +4,8 @@ module.exports = {
     STRIPE_PUBLISHABLE_KEY: 'pk_test_daBepdMharNP0PTQYoyQJPjH'
   },
   SERVER: {
+    HOST: '0.0.0.0',
+    PORT: 8000,
     UBUNTU_SSO_URL: 'https://login.ubuntu.com',
     UBUNTU_SCA_URL: 'https://myapps.developer.ubuntu.com',
     OPENID: {


### PR DESCRIPTION
Also fixes nconf env usage a little so that setting `FOO__BAR` and doing `config.get('FOO:BAR')` will actually work.