### PR TITLE
Added static notification under page contents

### DIFF
--- a/src/actions/customer.js
+++ b/src/actions/customer.js
@@ -30,7 +30,7 @@ export function sendStripeTokenFailure(errors) {
     dispatch(showNotification({
       message: [
         'There\'s been a problem adding your card.',
-        'Please verify that card details you provided are correct or use a differenct card and try again.'
+        'Please verify that card details you provided are correct or use a different card and try again.'
       ].join(' '),
       status: 'error',
       action: () => {

--- a/src/actions/customer.js
+++ b/src/actions/customer.js
@@ -18,11 +18,6 @@ export function sendStripeToken(token) {
 
 export function sendStripeTokenSuccess(tosAccepted) {
   return (dispatch) => {
-    dispatch(showNotification({
-      message: 'Your card has been added successfully',
-      status: 'success'
-    }));
-
     dispatch({
       type: SEND_STRIPE_TOKEN_SUCCESS,
       tosAccepted
@@ -35,7 +30,7 @@ export function sendStripeTokenFailure(errors) {
     dispatch(showNotification({
       message: [
         'There\'s been a problem adding your card.',
-        'Please wait a bit and try again soon.'
+        'Please verify that card details you provided are correct or use a differenct card and try again.'
       ].join(' '),
       status: 'error',
       action: () => {

--- a/src/containers/app.css
+++ b/src/containers/app.css
@@ -1,5 +1,9 @@
-.notification {
+.fixedNotification {
   position: fixed;
   width: 100%;
   z-index: 1000;
+}
+
+.staticNotification {
+  composes: container from './container.css';
 }

--- a/src/containers/app.js
+++ b/src/containers/app.js
@@ -30,8 +30,6 @@ export class App extends Component {
           return <Oyez key={i} { ...oy}/>;
         })}
         { this.props.children }
-        <Header identity={ identity }/>
-        { this.props.children }
         {notifications.notification &&
           <div className={ styles.staticNotification }>
             <Notification { ...notifications.notification } />

--- a/src/containers/app.js
+++ b/src/containers/app.js
@@ -30,8 +30,10 @@ export class App extends Component {
           return <Oyez key={i} { ...oy}/>;
         })}
         { this.props.children }
+        <Header identity={ identity }/>
+        { this.props.children }
         {notifications.notification &&
-          <div className={ styles.notification }>
+          <div className={ styles.staticNotification }>
             <Notification { ...notifications.notification } />
           </div>
         }


### PR DESCRIPTION
Error notifications are now static in page content (under the form).

Removed success notifications when card is added (as we show thank you message inline already).

Improved API error text, to suggest users to use different card (as any card issue from stripe results in failed request from API).

<img width="959" alt="screen shot 2016-10-03 at 16 15 12" src="https://cloud.githubusercontent.com/assets/83575/19040720/92d7fb20-8985-11e6-8566-18bbdc87560b.png">

