### PR TITLE
Use rsync to update build git repo

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,8 @@ CHARM_SERIES ?= xenial
 CHARM_SRC ?= $(CURDIR)/charm
 JUJU_REPOSITORY = $(BUILDDIR)
 CHARMDIR = $(BUILDDIR)/$(CHARM_SERIES)/$(NAME)
-GIT_CHARMDIR = $(CHARMDIR)/.git
+CHARMREPODIR = $(BUILDDIR)/build
+GIT_CHARMREPODIR = $(CHARMREPODIR)/.git
 PAYLOAD = $(CHARMDIR)/files/$(NAME).tgz
 CHARM = $(CHARMDIR)/.done
 LAYER_PATH = $(TMPDIR)/layer
@@ -27,6 +28,7 @@ EXTRA_CHARM_BUILD_ARGS ?=
 DEPLOY_ENV ?= devel
 DISTDIR = dist
 DIST = $(DISTDIR)/.done
+GIT_HEAD_HASH = $(shell git rev-parse HEAD)
 
 export INTERFACE_PATH
 export LAYER_PATH
@@ -38,11 +40,19 @@ $(CHARM_DEPS): $(TMPDIR) $(CHARM_SRC)/charm-deps
 	touch $(CHARM_DEPS)
 
 $(CHARM): $(CHARM_SRC) $(CHARM_SRC)/* $(CHARM_PREQS) $(CHARM_DEPS) | $(BUILDDIR)
+	rm -rf $(CHARMDIR)
 	PIP_NO_INDEX=true PIP_FIND_LINKS=$(CHARM_WHEELDIR) charm build -o $(BUILDDIR) -s $(CHARM_SERIES) -n $(NAME) $(EXTRA_CHARM_BUILD_ARGS) ./charm
 	touch $@
 
 version-info:
-	git rev-parse HEAD > $@.txt
+	echo '$(GIT_HEAD_HASH)' > $@.txt
+
+clean:
+	rm -rf $(BUILDDIR)
+	rm -rf $(TMPDIR)
+	rm -f $(PAYLOAD)
+	rm -rf dist
+	rm -rf node_modules
 
 .DELETE_ON_ERROR: $(DISTDIR)
 .INTERMEDIATE: $(DISTDIR)
@@ -54,13 +64,10 @@ $(DIST):
 	touch $@
 
 $(PAYLOAD): $(CHARM) $(DIST) version-info build-tar-exclude.txt $(SRC) $(SRC)/* $(SRC_PREQS)
-	rm -f $(PAYLOAD)
 	tar cz --exclude-vcs --exclude-from build-tar-exclude.txt -f $(PAYLOAD) .
 
 ## build the charm and payload
-build:
-	rm -rf $(CHARMDIR)
-	$(MAKE) $(PAYLOAD)
+build: $(PAYLOAD)
 
 deploy: build
 	juju deploy local:$(CHARM_SERIES)/$(NAME)
@@ -70,28 +77,25 @@ deploy: build
 		environment=$(DEPLOY_ENV) \
 		memcache_session_secret='its another secret'
 
+
+# Targets for building, committing and pushing charm builds to a git repo
+
 check-git-build-vars:
 ifndef BUILDREPO
 	$(error BUILDREPO is required)
 endif
 
-$(GIT_CHARMDIR): check-git-build-vars
+$(GIT_CHARMREPODIR): check-git-build-vars
 	rm -rf $(BUILDDIR)
-	mkdir -p $(BUILDDIR)/$(CHARM_SERIES)
-	git clone --branch $(BUILDBRANCH) $(BUILDREPO) $(CHARMDIR)
+	git clone --branch $(BUILDBRANCH) $(BUILDREPO) $(CHARMREPODIR)
 
 git-build: BUILDBRANCH ?= staging
 git-build: EXTRA_CHARM_BUILD_ARGS = --force
-git-build: $(GIT_CHARMDIR) $(PAYLOAD)
-	cd $(CHARMDIR) && GIT_DIR=$(GIT_CHARMDIR) git add .
-	cd $(CHARMDIR) && GIT_DIR=$(GIT_CHARMDIR) git commit -am "Build of $(NAME) from $$(cat $(CURDIR)/version-info.txt)"
-	cd $(CHARMDIR) && GIT_DIR=$(GIT_CHARMDIR) git push origin $(BUILDBRANCH)
-
-clean:
-	rm -rf $(BUILDDIR)
-	rm -rf $(TMPDIR)
-	rm -f $(PAYLOAD)
-	rm -rf dist
-	rm -rf node_modules
+git-build: RSYNC_EXCLUDES = --exclude=.git --exclude=.gitignore --exclude=.done --exclude=.build.manifest
+git-build: $(GIT_CHARMREPODIR) build
+	rsync -a -m --ignore-times --delete $(RSYNC_EXCLUDES) $(CHARMDIR) $(CHARMREPODIR)
+	cd $(CHARMREPODIR) && GIT_DIR=$(GIT_CHARMREPODIR) git add .
+	cd $(CHARMREPODIR) && GIT_DIR=$(GIT_CHARMREPODIR) git commit -am "Build of $(NAME) from $(GIT_HEAD_HASH)"
+	cd $(CHARMREPODIR) && GIT_DIR=$(GIT_CHARMREPODIR) git push origin $(BUILDBRANCH)
 
 .PHONY: version-info build deploy clean

--- a/charm/dependencies-devel.txt
+++ b/charm/dependencies-devel.txt
@@ -3,4 +3,5 @@ charm-tools
 python-codetree
 git
 make
+rsync
 virtualenv


### PR DESCRIPTION
By using `rsync` to synchronise built charm files we can ensure that a bunch of VCS ditritus and build files (`.done`, `.build.manifest` for example) are excluded from build asset git repo when invoking `make git-build`.