### PR TITLE
Always set port to 8000 in the charm

### DIFF
--- a/charm/reactive/javan_rhino.py
+++ b/charm/reactive/javan_rhino.py
@@ -35,6 +35,7 @@ def configure(cache):
             })
         check_port('ols.{}.express'.format(service_name()), port())
         set_state('service.configured')
+        hookenv.status_set('active', 'systemd unit configured')
     else:
         hookenv.status_set('blocked',
                            'Service requires session_secret and '

--- a/charm/templates/javan-rhino_systemd.j2
+++ b/charm/templates/javan-rhino_systemd.j2
@@ -10,6 +10,7 @@ Environment='SESSION_SECRET={{ session_secret }}'
 Environment='SERVER__LOGS_PATH={{ logs_path }}'
 Environment='SESSION_MEMCACHED_HOST={{ cache_hosts | join(",") }}'
 Environment='SESSION_MEMCACHED_SECRET={{ memcache_session_secret }}'
+Environment='SERVER__PORT=8000'
 WorkingDirectory={{ working_dir }}
 User={{ user }}
 {% if environment.startswith('devel') %}

--- a/charm/templates/javan-rhino_systemd.j2
+++ b/charm/templates/javan-rhino_systemd.j2
@@ -13,13 +13,8 @@ Environment='SESSION_MEMCACHED_SECRET={{ memcache_session_secret }}'
 Environment='SERVER__PORT=8000'
 WorkingDirectory={{ working_dir }}
 User={{ user }}
-{% if environment.startswith('devel') %}
-Environment='DEPLOY_ENV=development'
-ExecStart=/usr/bin/npm start
-{% else %}
 Environment='DEPLOY_ENV={{ environment }}'
 ExecStart=/usr/bin/npm run start-prod
-{% endif %}
 Restart=on-failure
 RestartSec=15 5
 


### PR DESCRIPTION
Ensure that javan-rhino when deployed with the charm is always on port 8000.

Also ensures the "blocking" status is reset to "active" when properly configured.