### PR TITLE
179: Remove deprecated development methods

### DIFF
--- a/src/server/index.js
+++ b/src/server/index.js
@@ -4,7 +4,6 @@ const WebPackIsomorphicTools = require('webpack-isomorphic-tools');
 const basePath = require('path').resolve(__dirname, '../..');
 
 const webpackIsomorphicTools = new WebPackIsomorphicTools(require('../../webpack/webpack-isomorphic-tools-configuration'))
-  .development(process.env.NODE_ENV !== 'production')
   .server(basePath, function() {
     require('./server').default(webpackIsomorphicTools);
   });


### PR DESCRIPTION
- Deleted code using webpack-isomorphic-tools method "development". The
  method is deprecated and now does nothing.