### PR TITLE
Not relying on latest_tos_accepted to show success message

### DIFF
--- a/src/common/actions/customer.js
+++ b/src/common/actions/customer.js
@@ -17,6 +17,11 @@ export function sendStripeToken(token) {
 }
 
 export function sendStripeTokenSuccess(tosAccepted) {
+  // TODO:
+  // if tosAccepted (latest_tos_accepted from JSON is false) is an edge case
+  // that should be logged to sentry once we have it set up
+  // https://github.com/canonical-ols/javan-rhino/issues/151
+  // https://github.com/canonical-ols/javan-rhino/issues/184
   return (dispatch) => {
     dispatch({
       type: SEND_STRIPE_TOKEN_SUCCESS,

--- a/src/common/containers/add-card.js
+++ b/src/common/containers/add-card.js
@@ -23,10 +23,10 @@ export class AddCard extends Component {
         />
         <Welcome />
         <SignInBanner identity={ identity } url={ url } />
-        { !this.props.customer.tosAccepted &&
+        { !this.props.customer.success &&
           <PaymentsForm />
         }
-        { this.props.customer.tosAccepted &&
+        { this.props.customer.success &&
           <div>
             <PaymentDetails />
             <CustomerSuccess />
@@ -41,7 +41,7 @@ AddCard.propTypes = {
   dispatch: PropTypes.func.isRequired,
   customer: PropTypes.shape({
     isFetching: PropTypes.bool,
-    tosAccepted: PropTypes.bool
+    success: PropTypes.bool
   }).isRequired,
   stripe: PropTypes.shape({
     isFetching: PropTypes.bool,

--- a/src/common/reducers/customer.js
+++ b/src/common/reducers/customer.js
@@ -2,6 +2,7 @@ import * as ActionTypes from '../actions/customer';
 
 export function customer(state = {
   isFetching: false,
+  success: false,
   tosAccepted: false,
   errors: false,
   token: false
@@ -17,12 +18,14 @@ export function customer(state = {
       return {
         ...state,
         isFetching: false,
+        success: true,
         tosAccepted: action.tosAccepted
       };
     case ActionTypes.SEND_STRIPE_TOKEN_FAILURE:
       return {
         ...state,
         isFetching: false,
+        success: false,
         errors: action.errors
       };
     default:

--- a/test/unit/src/common/containers/t_add-card.js
+++ b/test/unit/src/common/containers/t_add-card.js
@@ -20,7 +20,7 @@ describe('<AddCard /> container', () => {
         validatedCardData: false
       },
       customer: {
-        tosAccepted: false
+        success: false
       }
     };
     wrapper = shallow(<AddCard { ...props }/>);
@@ -46,7 +46,7 @@ describe('<AddCard /> container', () => {
     expect(wrapper.find(CustomerSuccess).length).toBe(0);
   });
 
-  describe('with no tosAccepted', () => {
+  describe('with no customer success', () => {
     let wrapper;
 
     beforeEach(() => {
@@ -57,7 +57,7 @@ describe('<AddCard /> container', () => {
           validatedCardData: true
         },
         customer: {
-          tosAccepted: false
+          success: false
         }
       };
       wrapper = shallow(<AddCard { ...props }/>);

--- a/test/unit/src/common/reducers/t_customer.js
+++ b/test/unit/src/common/reducers/t_customer.js
@@ -9,6 +9,7 @@ describe('customer reducers', () => {
     expect(customer(undefined, {})).toEqual({
       errors: false,
       isFetching: false,
+      success: false,
       token: false,
       tosAccepted: false
     });
@@ -18,6 +19,7 @@ describe('customer reducers', () => {
     const state = {
       errors: false,
       isFetching: false,
+      success: false,
       token: false,
       tosAccepted: 'date string'
     };
@@ -29,6 +31,7 @@ describe('customer reducers', () => {
     expect(customer(state, action)).toEqual({
       errors: false,
       isFetching: true,
+      success: false,
       token: 'foo',
       tosAccepted: 'date string'
     });
@@ -42,6 +45,7 @@ describe('customer reducers', () => {
 
     expect(customer({}, action)).toEqual({
       isFetching: false,
+      success: true,
       tosAccepted: 'datetime'
     });
   });
@@ -54,6 +58,7 @@ describe('customer reducers', () => {
 
     expect(customer({}, action)).toEqual({
       isFetching: false,
+      success: false,
       errors: []
     });
   });


### PR DESCRIPTION
Fixes #151

We don't check if `latest_tos_accepted` is true anymore.

Case when it's false should be logged to sentry (once we have it): #184