### PR TITLE
Correctly read NODE_ENV from proccess.env

### DIFF
--- a/src/server/helpers/html.js
+++ b/src/server/helpers/html.js
@@ -5,7 +5,7 @@ import { Provider } from 'react-redux';
 
 import conf from '../../server/configure';
 
-const assetHost = (global.NODE_ENV === 'production') ? ''
+const assetHost = (process.env.NODE_ENV === 'production') ? ''
   : conf.get('SERVER:WEBPACK_DEV_URL');
 
 export default class Html extends Component {


### PR DESCRIPTION
It seems it slipped through the review. I found it when trying to debug something else running prod locally.