### PR TITLE
ship only the production build of node_modules

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -62,6 +62,7 @@ $(DIST):
 	mkdir -p $(DISTDIR)
 	npm install || (cat npm-debug.log && exit 1)
 	npm run build
+	npm install --production
 	touch $@
 
 $(PAYLOAD): $(CHARM) $(DIST) version-info build-exclude.txt $(SRC) $(SRC)/* $(SRC_PREQS)

--- a/Makefile
+++ b/Makefile
@@ -62,7 +62,7 @@ $(DIST):
 	mkdir -p $(DISTDIR)
 	npm install || (cat npm-debug.log && exit 1)
 	npm run build
-	npm install --production
+	npm install --production || (cat npm-debug.log && exit 1)
 	touch $@
 
 $(PAYLOAD): $(CHARM) $(DIST) version-info build-exclude.txt $(SRC) $(SRC)/* $(SRC_PREQS)


### PR DESCRIPTION
running `npm i --production` after `npm i` removes devDeps from node_modules, and reduces the churn in staging diffs, as well as reducing the deployed code size