### PR TITLE
Updated colour palette

### DIFF
--- a/src/common/style/variables.js
+++ b/src/common/style/variables.js
@@ -1,22 +1,24 @@
 module.exports = {
-  // based on http://design.ubuntu.com/web-style-guide
-  // and https://github.com/ubuntudesign/vanilla-framework
+  // based on:
+  // https://design.ubuntu.com/brand/colour-palette
+  // https://github.com/ubuntudesign/ubuntu-vanilla-theme
+  // https://github.com/ubuntudesign/vanilla-framework
 
-  'ubuntu-orange':       '#dd4814', // ubuntu orange (used for text links also on any site except canonical)
+  'ubuntu-orange':       '#e95420', // ubuntu orange (used for text links also on any site except canonical)
   'light-orange':        '#fdf6f2', // used as background on pre text
   'canonical-aubergine': '#772953', // canonical aubergine
   'light-aubergine':     '#77216f', // light aubergine (consumer)
   'mid-aubergine':       '#5e2750', // mid aubergine (both)
   'dark-aubergine':      '#2c001e', // dark aubergine (enterprise)
   'mid-grey':            '#cdcdcd',
-  'warm-grey':           '#888888', // warm grey
+  'warm-grey':           '#aea79f', // warm grey
   'cool-grey':           '#333333', // cool grey
   'light-grey':          '#f7f7f7', // light grey
 
-  'error':               '#df382c', // error notifications
-  'warning':             '#eca918', // warning notifications
-  'success':             '#38b44a', // success notifications
-  'information':         '#19b6ee', // information notifications
+  'error':               '#d73024', // error notifications
+  'warning':             '#f99b11', // warning notifications
+  'success':             '#0f8420', // success notifications
+  'information':         '#007aa6', // information notifications
 
   'base-font-family':    'Ubuntu, Arial, "libra sans", sans-serif',
   'base-font-weight':    '300',


### PR DESCRIPTION
It seems that we used old colour palette.

Updated based on current state of:
https://design.ubuntu.com/brand/colour-palette
https://github.com/ubuntudesign/ubuntu-vanilla-theme
https://github.com/ubuntudesign/vanilla-framework