### PR TITLE
Fix acceptance test sso confirm

### DIFF
--- a/test/acceptance/pages/payment.js
+++ b/test/acceptance/pages/payment.js
@@ -40,7 +40,6 @@ export default function(driver) {
       this.navigate();
       driver.findElement(elements.loginButton).click();
       sso.login();
-      sso.confirm();
       return driver.wait(until.elementLocated(elements.username));
     },
     getUsername: function() {

--- a/test/acceptance/www/payment/edit/t_edit.js
+++ b/test/acceptance/www/payment/edit/t_edit.js
@@ -38,7 +38,11 @@ const browsers = [{
   os_version: 'Sierra',
 }];
 
-const proxyUrl = url.parse(process.env.HTTP_PROXY);
+let proxyUrl = false;
+
+if (process.env.HTTP_PROXY) {
+  proxyUrl = url.parse(process.env.HTTP_PROXY);
+}
 
 for (let browser of browsers) {
 
@@ -62,19 +66,23 @@ for (let browser of browsers) {
         this.skip();
       }
 
-      driver = new Builder()
+      const builder = new Builder()
         .usingServer('https://hub.browserstack.com/wd/hub')
         .withCapabilities({
           ...capabilities,
           ...browser
-        })
-        .usingHttpAgent(httpsOverHttp({
+        });
+
+      if (proxyUrl) {
+        builder.usingHttpAgent(httpsOverHttp({
           proxy: {
             host: proxyUrl.hostname,
             port: proxyUrl.port
           }
-        }))
-        .build();
+        }));
+      }
+
+      driver = builder.build();
 
       driver.session_.then((sessionData) => {
         sessionId = sessionData.id_;


### PR DESCRIPTION
my.ubuntu.com is now trusted by SSO, so the SSO confirmation page is no longer presented to users. This PR removes that interaction from the acceptance test, but keeps it in the page object for future use/reference.