### PR TITLE
no need for statsd string here

### DIFF
--- a/src/server/middleware/metrics.js
+++ b/src/server/middleware/metrics.js
@@ -9,7 +9,6 @@ export function createStatName(stage='devel', unit, req, res) {
   const { statusCode } = res;
 
   let stat = [
-    'statsd',
     'ols',
     stage,
     'mu',

--- a/test/unit/src/server/middleware/t_metrics.js
+++ b/test/unit/src/server/middleware/t_metrics.js
@@ -27,13 +27,11 @@ describe('metrics middleware', function() {
   describe('createStatsdClient', function() {
 
     it('should create a lynx instance', function() {
-      expect(client)
-        .toBeA(lynx);
+      expect(client).toBeA(lynx);
     });
 
     it('should have correct scope', function() {
-      expect(client.scope)
-        .toBe('ols.');
+      expect(client.scope).toBe('ols.');
     });
 
   });

--- a/test/unit/src/server/middleware/t_metrics.js
+++ b/test/unit/src/server/middleware/t_metrics.js
@@ -1,11 +1,14 @@
 import expect from 'expect';
+import lynx from 'lynx';
 
 import {
+  createStatsdClient,
   createStatName
 } from '../../../../../src/server/middleware/metrics';
 
 describe('metrics middleware', function() {
 
+  let client;
   let req;
   let res;
 
@@ -17,23 +20,44 @@ describe('metrics middleware', function() {
     res = {
       statusCode: 200
     };
+
+    client = createStatsdClient('udp://localhost:1234', 'ols.');
+  });
+
+  describe('createStatsdClient', function() {
+
+    it('should create a lynx instance', function() {
+      expect(client)
+        .toBeA(lynx);
+    });
+
+    it('should have correct scope', function() {
+      expect(client.scope)
+        .toBe('ols.');
+    });
+
   });
 
   describe('createStatName', function() {
 
     it('should create a stat name', function() {
       expect(createStatName('staging', 'unit', req, res))
-        .toBe('ols.staging.mu.unit.views.foo_bar.GET.200.response');
+        .toBe('staging.mu.unit.views.foo_bar.GET.200.response');
     });
 
     it('should filter missing name parts', function() {
       expect(createStatName('staging', null, req, res))
-        .toBe('ols.staging.mu.views.foo_bar.GET.200.response');
+        .toBe('staging.mu.views.foo_bar.GET.200.response');
     });
 
     it('should sanitise urls', function() {
       expect(createStatName('staging', null, req, res))
-        .toBe('ols.staging.mu.views.foo_bar.GET.200.response');
+        .toBe('staging.mu.views.foo_bar.GET.200.response');
+    });
+
+    it('should default to devel', function() {
+      expect(createStatName(undefined, undefined, req, res))
+        .toBe('devel.mu.views.foo_bar.GET.200.response');
     });
   });
 });

--- a/test/unit/src/server/middleware/t_metrics.js
+++ b/test/unit/src/server/middleware/t_metrics.js
@@ -23,17 +23,17 @@ describe('metrics middleware', function() {
 
     it('should create a stat name', function() {
       expect(createStatName('staging', 'unit', req, res))
-        .toBe('statsd.ols.staging.mu.unit.views.foo_bar.GET.200.response');
+        .toBe('ols.staging.mu.unit.views.foo_bar.GET.200.response');
     });
 
     it('should filter missing name parts', function() {
       expect(createStatName('staging', null, req, res))
-        .toBe('statsd.ols.staging.mu.views.foo_bar.GET.200.response');
+        .toBe('ols.staging.mu.views.foo_bar.GET.200.response');
     });
 
     it('should sanitise urls', function() {
       expect(createStatName('staging', null, req, res))
-        .toBe('statsd.ols.staging.mu.views.foo_bar.GET.200.response');
+        .toBe('ols.staging.mu.views.foo_bar.GET.200.response');
     });
   });
 });


### PR DESCRIPTION
* in graphite stats are appearing in 'statsd.statsd' so we can drop one of those :)
* set the scope to be 'ols'.
* create client instance once.