### PR TITLE
try a longer timeout, see if recent failures are resolved

### DIFF
--- a/test/acceptance/runner.js
+++ b/test/acceptance/runner.js
@@ -9,7 +9,7 @@ const files = glob.sync('/**/t_*.js', {
 });
 const mocha = new Mocha({
   fullTrace: true,
-  timeout: 30000,
+  timeout: 100000,
   reporter: 'spec'
 });
 


### PR DESCRIPTION
seeing timeouts in selenium acceptance tests on afterAll, tests have passed in browserstack but jenkins gets a failure because mocha times out ... try longer timeout first.