### PR TITLE
Add JUJU_UNIT and SERVICE_ENVIRONMENT variables

### DIFF
--- a/charm/reactive/javan_rhino.py
+++ b/charm/reactive/javan_rhino.py
@@ -21,25 +21,25 @@ SYSTEMD_CONFIG = '/lib/systemd/system/javan-rhino.service'
 def configure(cache):
     environment = hookenv.config('environment')
     juju_unit = hookenv.local_unit()
-    session_secret = hookenv.config('session_secret')
     memcache_session_secret = hookenv.config('memcache_session_secret')
     sentry_dsn = hookenv.config('sentry_dsn')
+    session_secret = hookenv.config('session_secret')
     statsd_dsn = hookenv.config('statsd_dsn')
     if session_secret and memcache_session_secret:
         render(
             source='javan-rhino_systemd.j2',
             target=SYSTEMD_CONFIG,
             context={
-                'working_dir': code_dir(),
-                'user': user(),
-                'session_secret': session_secret,
-                'logs_path': logs_dir(),
-                'environment': environment,
                 'cache_hosts': cache.memcache_hosts(),
+                'environment': environment,
+                'juju_unit': juju_unit,
+                'logs_path': logs_dir(),
                 'memcache_session_secret': memcache_session_secret,
                 'sentry_dsn': sentry_dsn,
+                'session_secret': session_secret,
                 'statsd_dsn': statsd_dsn,
-                'juju_unit': juju_unit,
+                'user': user(),
+                'working_dir': code_dir(),
             })
         check_port('ols.{}.express'.format(service_name()), port())
         set_state('service.configured')

--- a/charm/reactive/javan_rhino.py
+++ b/charm/reactive/javan_rhino.py
@@ -20,6 +20,7 @@ SYSTEMD_CONFIG = '/lib/systemd/system/javan-rhino.service'
 @restart_on_change({SYSTEMD_CONFIG: ['javan-rhino']}, stopstart=True)
 def configure(cache):
     environment = hookenv.config('environment')
+    juju_unit = hookenv.local_unit()
     session_secret = hookenv.config('session_secret')
     memcache_session_secret = hookenv.config('memcache_session_secret')
     sentry_dsn = hookenv.config('sentry_dsn')
@@ -38,6 +39,7 @@ def configure(cache):
                 'memcache_session_secret': memcache_session_secret,
                 'sentry_dsn': sentry_dsn,
                 'statsd_dsn': statsd_dsn,
+                'juju_unit': juju_unit,
             })
         check_port('ols.{}.express'.format(service_name()), port())
         set_state('service.configured')

--- a/charm/templates/javan-rhino_systemd.j2
+++ b/charm/templates/javan-rhino_systemd.j2
@@ -6,6 +6,7 @@ Description=Front-end to Ubuntu Store Payments
 
 [Service]
 Type=simple
+Environment='JUJU_UNIT={{ juju_unit.replace('/', '-') }}'
 Environment='SENTRY_DSN={{ sentry_dsn }}'
 Environment='SERVER__LOGS_PATH={{ logs_path }}'
 Environment='SERVICE_ENVIRONMENT={{ environment }}'

--- a/charm/templates/javan-rhino_systemd.j2
+++ b/charm/templates/javan-rhino_systemd.j2
@@ -6,11 +6,12 @@ Description=Front-end to Ubuntu Store Payments
 
 [Service]
 Type=simple
-Environment='SESSION_SECRET={{ session_secret }}'
+Environment='SENTRY_DSN={{ sentry_dsn }}'
 Environment='SERVER__LOGS_PATH={{ logs_path }}'
+Environment='SERVICE_ENVIRONMENT={{ environment }}'
 Environment='SESSION_MEMCACHED_HOST={{ cache_hosts | join(",") }}'
 Environment='SESSION_MEMCACHED_SECRET={{ memcache_session_secret }}'
-Environment='SENTRY_DSN={{ sentry_dsn }}'
+Environment='SESSION_SECRET={{ session_secret }}'
 Environment='STATSD_DSN={{ statsd_dsn }}'
 WorkingDirectory={{ working_dir }}
 User={{ user }}


### PR DESCRIPTION
These variables will be set in the environment available to the service, via the systemd file's Environment directives.

JUJU_UNIT will have any slashes replaced by hyphens (so javan-rhino/0 becomes javan-rhino-0 as is conventional for e.g. usage in statsd identifiers).

