### PR TITLE
Add extra environment variables (incl. JUJU_UNIT and SERVICE_ENVIRONMENT)

### DIFF
--- a/charm/charm-deps
+++ b/charm/charm-deps
@@ -8,9 +8,9 @@ interface/interface-pgsql           git+ssh://git.launchpad.net/interface-pgsql;
 interface/interface-wsgi            git+ssh://git.launchpad.net/~ubuntuone-hackers/charms/+source/interface-wsgi;revno=04cab5b
 
 layer                               @
-layer/layer-apt                     git+ssh://git.launchpad.net/layer-apt;revno=608bdf5
-layer/layer-basic                   lp:~ubuntuone-hackers/ols-charm-deps/layer-basic;revno=62
-layer/layer-ols                     lp:~ubuntuone-hackers/ols-charm-deps/layer-ols;revno=13
-layer/layer-ols-http                lp:~ubuntuone-pqm-team/ols-charm-deps/layer-ols-http;revno=3
+layer/layer-apt                     git+ssh://git.launchpad.net/layer-apt;revno=36f956aa97
+layer/layer-basic                   lp:~ubuntuone-hackers/ols-charm-deps/layer-basic;revno=68
+layer/layer-ols                     lp:~ubuntuone-pqm-team/ols-charm-deps/layer-ols;revno=17
+layer/layer-ols-http                lp:~ubuntuone-pqm-team/ols-charm-deps/layer-ols-http;revno=7
 
 wheels                              git+ssh://git.launchpad.net/~ubuntuone-hackers/ols-charm-deps/+git/wheels

--- a/charm/templates/javan-rhino_env.j2
+++ b/charm/templates/javan-rhino_env.j2
@@ -1,0 +1,10 @@
+#--------------------------------------------------------------
+# This file is managed by Juju; ANY CHANGES WILL BE OVERWRITTEN
+#--------------------------------------------------------------
+# Additional environment variables for javan-rhino
+{% if env_extra -%}
+{% for k, v in env_extra -%}
+{{ k }}="{{ v }}"
+{% endfor -%}
+{% endif -%}
+

--- a/charm/templates/javan-rhino_systemd.j2
+++ b/charm/templates/javan-rhino_systemd.j2
@@ -12,6 +12,9 @@ Environment='SESSION_MEMCACHED_HOST={{ cache_hosts | join(",") }}'
 Environment='SESSION_MEMCACHED_SECRET={{ memcache_session_secret }}'
 Environment='SENTRY_DSN={{ sentry_dsn }}'
 Environment='STATSD_DSN={{ statsd_dsn }}'
+{% if env_file %}
+EnvironmentFile={{ env_file }}
+{% endif %}
 WorkingDirectory={{ working_dir }}
 User={{ user }}
 ExecStart=/usr/bin/npm run start-build -- --env=environments/{{ environment }}.env


### PR DESCRIPTION
This renders the common extra variables (including JUJU_UNIT and SERVICE_ENVIRONMENT among others) defined by the OLS layer (and possibly others) into a file in the service's etc/ directory. This file can trivially be used via EnvironmentFile in the systemd unit (also done here) or sourced manually if the service needs to be diagnosed or otherwise run manually. This approach should be closer to recommended best practice on the OLS layer family and allows for easily moving the existing Environment= variables to the env file. I didn't do that but can add that in a subsequent commit if reviewers think it's worth doing.